### PR TITLE
replace hard paths for new disk with variable 'newdisk'

### DIFF
--- a/wubi-resize.sh
+++ b/wubi-resize.sh
@@ -225,7 +225,7 @@ sanity_checks ()
     newdisk=/host/ubuntu/disks/new.disk
     if [ -f "$newdisk" ]; then
       if [ "$resume" == "true" ]; then
-        new_size=$(du -b /host/ubuntu/disks/new.disk 2> /dev/null | cut -f 1)
+        new_size=$(du -b "$newdisk" 2> /dev/null | cut -f 1)
         new_size=`echo "$new_size / 1000000000" | bc`  #assumes made by this program, otherwise will underreport
         echo "$0: resuming previous attempt - size is "$new_size" GB"
         size=$new_size # edit size check with actual size, not inputted size
@@ -311,7 +311,7 @@ sanity_checks ()
               echo "$0: Resize of $newdisk to $sizeG failed"
               exit 1
             fi
-            new_size=$(du -b /host/ubuntu/disks/new.disk 2> /dev/null | cut -f 1)
+            new_size=$(du -b "$newdisk" 2> /dev/null | cut -f 1)
             new_size=`echo "$new_size / 1000000000" | bc`  #assumes made by this program, otherwise will underreport
             echo "$0: "$newdisk" resized to "$new_size" GB"
           fi


### PR DESCRIPTION
There are two instances where `/host/ubuntu/disks/new.disk` is used directly, instead of the existing variable `newdisk`. This fixes this minor issue. 

I came across this while wanting to resize a wubi virtual disk but place the new virtual disk in an external hard drive. The problem was that the hard disk on which the old wubi virtual disk was placed had already limited free space. To resize/grow the virtual disk, I had to resize the virtual disk and place on a hard drive that could fit the new size, then remove the old virtual disk and move the new virtual disk to the hard drive that previously couldn't fit the new virtual disk size (now it does as the space used by the old virtual disk has been freed..)

I am keen on making the path to place the new virtual disk an argument, but I think it will not be of much use. Should I ?

I was also not sure if I should make the pull request again `master`, but it's fairly trivial so I guess it's alright.

Thanks
